### PR TITLE
fix: follow other screen lockers on default pam cfg name & other pam changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,6 +685,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -689,6 +779,7 @@ name = "coldlock"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "clap",
  "iced",
  "iced_sessionlock",
  "pam-f",
@@ -700,6 +791,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1521,6 +1618,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1981,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
@@ -2819,6 +2928,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "orbclient"
@@ -4067,6 +4182,12 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ iced = { version = "0.14", features = ["advanced", "image", "smol"] }
 iced_sessionlock = { version = "0.18.1", default-features = false }
 uzers = "0.12.2"
 chrono = "0.4.45"
+clap = { version = "4.6.1", features = ["derive"] }

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -23,6 +23,6 @@ in {
   config = mkIf cfg.enable {
     environment.systemPackages = [cfg.package];
 
-    security.pam.services.system-auth = {};
+    security.pam.services.coldlock = {};
   };
 }

--- a/pam/coldlock
+++ b/pam/coldlock
@@ -1,0 +1,6 @@
+#
+# PAM configuration file for the coldlock screen locker. By default, it includes
+# the 'login' configuration file (see /etc/pam.d/login).
+#
+
+auth include login

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use chrono::{Local, Timelike};
+use clap::Parser;
 use iced::keyboard::key;
 use iced::widget::{Image, Stack, column, container, image, text, text_input};
 use iced::window::Id;
@@ -26,8 +27,27 @@ static IMAGE_B_HANDLE: LazyLock<image::Handle> =
     LazyLock::new(|| image::Handle::from_bytes(IMAGE_B));
 static ACCOUNT_DEFAULT_HANDLE: LazyLock<image::Handle> =
     LazyLock::new(|| image::Handle::from_bytes(ACCOUNT));
+
+/// ColdLock — a Wayland session locker.
+#[derive(clap::Parser)]
+#[command(name = "coldlock", version, about)]
+struct Args {
+    /// PAM service to authenticate against (must have a config in /etc/pam.d).
+    #[arg(long, default_value = "coldlock")]
+    pam: String,
+}
+
 fn main() -> Result<(), iced_sessionlock::Error> {
-    application(Lock::new, Lock::update, Lock::view)
+    let args = Args::parse();
+    let service: &'static str = Box::leak(args.pam.into_boxed_str());
+
+    if !std::path::Path::new(&format!("/etc/pam.d/{service}")).exists() {
+        eprintln!("coldlock: PAM service '{service}' has no config in /etc/pam.d.");
+        eprintln!("Refusing to lock.");
+        std::process::exit(1);
+    }
+
+    application(move || Lock::new(service), Lock::update, Lock::view)
         .theme(Lock::theme)
         .subscription(Lock::subscription)
         .run()
@@ -48,10 +68,10 @@ enum Message {
 }
 
 impl Lock {
-    fn new() -> (Self, Command<Message>) {
+    fn new(service: &'static str) -> (Self, Command<Message>) {
         (
             Self {
-                steps: AuthSteps::new(),
+                steps: AuthSteps::new(service),
                 aligned: false,
             },
             Command::none(),
@@ -113,7 +133,7 @@ struct AuthSteps {
 }
 
 impl AuthSteps {
-    fn new() -> AuthSteps {
+    fn new(service: &'static str) -> AuthSteps {
         let user = get_user_by_uid(get_current_uid()).unwrap();
         let user_name = user.name().to_string_lossy().to_string().clone();
         let icon_path = format!("/var/lib/AccountsService/icons/{user_name}");
@@ -138,6 +158,7 @@ impl AuthSteps {
                     name: user_name.clone(),
                     password: String::new(),
                     auth_error: String::new(),
+                    service,
                 },
             ],
             current: 0,
@@ -173,6 +194,7 @@ enum AuthStep {
         name: String,
         password: String,
         auth_error: String,
+        service: &'static str,
     },
 }
 
@@ -211,16 +233,17 @@ impl<'a> AuthStep {
                 if let AuthStep::Auth {
                     name,
                     password,
-                    auth_error: _auth_error,
+                    service,
                     ..
                 } = self
                 {
                     let name = name.clone();
                     let password = password.clone();
+                    let service = *service;
                     return Command::perform(
                         async move {
-                            let mut client = Client::with_password("system-auth")
-                                .expect("Failed to init PAM client.");
+                            let mut client =
+                                Client::with_password(service).expect("Failed to init PAM client.");
                             client.conversation_mut().set_credentials(&name, &password);
                             client.authenticate()
                         },
@@ -253,6 +276,7 @@ impl<'a> AuthStep {
                 password,
                 auth_error,
                 icon_handle,
+                service: _,
             } => Self::auth(name, password, auth_error, icon_handle.clone()),
         }
     }


### PR DESCRIPTION
Screen lockers like swaylock, hyprlock,etc...  all use their name as default pam config name, good idea to follow that standard.

When first time used coldlock, forgot to create pam file, so locked myself out of system. That's why created check if config exists. We don't validate it, as I got no idea how to do that without over-complicating logic, but at least that check is nice to have.

Arg is for people who play around with pam, so other than default can be used.
